### PR TITLE
Define shared network data structures

### DIFF
--- a/src/network_structs.hpp
+++ b/src/network_structs.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+namespace network_structs {
+
+    enum class PacketType : uint16_t {
+        DISCOVERY = 1,
+        REQUEST = 2,
+        DISCOVERY_ACK = 3,
+        REQUEST_ACK = 4
+    };
+
+    struct RequestPayload {
+        uint32_t dest_addr;
+        uint32_t value;
+    };
+
+    struct AckPayload {
+        uint32_t new_balance;
+    };
+
+    struct Packet {
+        PacketType type;
+        uint32_t sequence_number;
+
+        union {
+            RequestPayload req;
+            AckPayload ack;
+        } data;
+    };
+
+}


### PR DESCRIPTION
### Changes:
- Add `network_structs.hpp` file with all shared data types, which was the main prerequisite to begin parallel development on the client and server